### PR TITLE
Resolving SubmitHashes Defect

### DIFF
--- a/chainpoint.go
+++ b/chainpoint.go
@@ -241,7 +241,7 @@ func submitHashesToNode(queue chan submitHashesResponse, w *sync.WaitGroup, URI 
 	defer w.Done()
 	var submitHashesResponse submitHashesResponse
 
-	hashesList := make([]string, len(hashes))
+	var hashesList []string
 	for _, hash := range hashes {
 		hashesList = append(hashesList, string(hash))
 	}


### PR DESCRIPTION
## Defect:
Failed hash submissions to Chainpoint Network

## Discovered Reason:
Request body in call to submit hashes to Chainpoint Network consisted of an array with empty values alongside 32byte hashes.

## Fix:
Improperly initializing array of hashes to submit to the length of hashes provided to the `SubmitHashes()` method, and later appending additional items to this array.

## Steps to Test:
Run Goldmine using latest version of this Package and observe that Chainpoint Proofs are being generated and retrieved with Goldmine.